### PR TITLE
Also test other O/S versions

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -31,8 +31,11 @@ jobs:
           - "ubuntu:jammy" # ubuntu/22.04
           - "debian:stretch"
           - "debian:buster"
+          - "debian:bullseye"
+          - "debian:bookworm"
           - "centos:7"
-          - "rockylinux:8"     # compatible with EOL centos:8
+          - "rockylinux:8"     # compatible with RHEL/CentOS 8
+          - "rockylinux:9"     # compatible with RHEL 9
         target: x86_64
         include:
           # package for the Raspberry Pi 1b as an ARMv6 cross compiled variant of the Debian Buster upon which

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -85,13 +85,13 @@ jobs:
             deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
 
           - image: "debian:buster"
-          deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
+            deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
 
           - image: "debian:bullseye"
-          deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
+            deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
 
           - image: "debian:bookworm"
-          deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
+            deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
 
       package_test_rules: pkg/rules/package-test-rules.yml
       package_test_scripts_path: pkg/test-scripts/test-<package>.sh

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -4,7 +4,13 @@ on:
   push:
 
   workflow_dispatch:
-
+    inputs:
+      single_job:
+        description: 'Runs only the specified job'
+        required: false
+        type: string
+        default: ''
+  
   schedule:
     - cron: '0 0 * * 0'
 
@@ -12,6 +18,7 @@ on:
 
 jobs:
   full:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'full' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -91,6 +98,7 @@ jobs:
         enabled=1
 
   check_full:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'full' }}
     runs-on: ubuntu-latest
     needs: full
     steps:
@@ -109,9 +117,11 @@ jobs:
             core.setFailed("Expected Docker manifest to have been published but output `docker_manifest_published` is false")
 
   minimal:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'minimal' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
 
   no_test_scripts:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'no_test_scripts' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -138,6 +148,7 @@ jobs:
         enabled=1
 
   default_tests:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'default_tests' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -158,6 +169,7 @@ jobs:
       rpm_scriptlets_path: pkg/rpm/scriptlets.toml
 
   default_tests_with_upgrades:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'default_tests_with_upgrades' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -215,6 +227,7 @@ jobs:
         enabled=1
 
   no_tests:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'no_tests' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -241,6 +254,7 @@ jobs:
         enabled=1
 
   no_docker:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'no_docker' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     with:
       artifact_prefix: no_docker_
@@ -263,6 +277,7 @@ jobs:
         enabled=1
 
   only_docker:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'only_docker' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -273,19 +288,8 @@ jobs:
       docker_repo: ploutos-testing_only_docker
       docker_build_rules: pkg/rules/docker-build-rules.yml
 
-  docker_no_secrets:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
-    with:
-      artifact_prefix: docker_no_secrets_
-
-      docker_org: ximoneighteen
-      docker_repo: ploutos-testing_docker_no_secrets
-      docker_build_rules: |
-        platform: ["linux/amd64"]
-        shortname: ["amd64"]
-        mode: ["build"]
-
   check_only_docker:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'only_docker' }}
     runs-on: ubuntu-latest
     needs: only_docker
     steps:
@@ -302,7 +306,21 @@ jobs:
           script: |
             core.setFailed("Expected Docker manifest to have been published but output `docker_manifest_published` is false")
 
+  docker_no_secrets:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'docker_no_secrets' }}
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
+    with:
+      artifact_prefix: docker_no_secrets_
+
+      docker_org: ximoneighteen
+      docker_repo: ploutos-testing_docker_no_secrets
+      docker_build_rules: |
+        platform: ["linux/amd64"]
+        shortname: ["amd64"]
+        mode: ["build"]
+          
   no_cross:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'no_cross' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -329,6 +347,7 @@ jobs:
         enabled=1
 
   check_no_cross:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'no_cross' }}
     runs-on: ubuntu-latest
     needs: no_cross
     steps:
@@ -346,6 +365,7 @@ jobs:
             core.setFailed("Expected Docker manifest to have been published but output `docker_manifest_published` is false")
   
   test_with_alt_pkg:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'test_with_alt_pkg' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
@@ -371,6 +391,7 @@ jobs:
       rpm_scriptlets_path: pkg/rpm/scriptlets.toml
 
   test_with_alt_cargo_toml:
+    if: ${{ inputs.single_job == '' || inputs.single_job == 'test_with_alt_cargo_toml' }}
     uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -73,6 +73,7 @@ jobs:
           - image: "rockylinux:9"
             systemd_service_unit_file: "pkg/common/mytest.mytest.*"
             target: "x86_64"
+            rpm_rpmlint_check_filters: "no-documentation no-manual-page-for-binary"
 
           - image: "ubuntu:bionic"
             deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       single_job:
-        description: 'Runs only the specified job'
+        description: 'Run only the specified job'
         required: false
         type: string
         default: ''
@@ -69,6 +69,10 @@ jobs:
             target: "x86_64"
             os: "centos:8"
             rpm_rpmlint_check_filters: "no-documentation no-manual-page-for-binary"
+
+          - image: "rockylinux:9"
+            systemd_service_unit_file: "pkg/common/mytest.mytest.*"
+            target: "x86_64"
 
           - image: "ubuntu:bionic"
             deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -85,7 +85,13 @@ jobs:
             deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
 
           - image: "debian:buster"
-            deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
+          deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
+
+          - image: "debian:bullseye"
+          deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
+
+          - image: "debian:bookworm"
+          deb_extra_lintian_args: "--suppress-tags binary-without-manpage,changelog-not-compressed-with-max-compression"
 
       package_test_rules: pkg/rules/package-test-rules.yml
       package_test_scripts_path: pkg/test-scripts/test-<package>.sh

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   full:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: full_
@@ -106,10 +106,10 @@ jobs:
             core.setFailed("Expected Docker manifest to have been published but output `docker_manifest_published` is false")
 
   minimal:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
 
   no_test_scripts:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: no_test_scripts_
@@ -135,7 +135,7 @@ jobs:
         enabled=1
 
   default_tests:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: default_tests_
@@ -155,7 +155,7 @@ jobs:
       rpm_scriptlets_path: pkg/rpm/scriptlets.toml
 
   default_tests_with_upgrades:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: default_tests_with_upgrades_
@@ -212,7 +212,7 @@ jobs:
         enabled=1
 
   no_tests:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: no_tests_
@@ -238,7 +238,7 @@ jobs:
         enabled=1
 
   no_docker:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     with:
       artifact_prefix: no_docker_
       cross_build_args: --no-default-features
@@ -260,7 +260,7 @@ jobs:
         enabled=1
 
   only_docker:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: only_docker_
@@ -271,7 +271,7 @@ jobs:
       docker_build_rules: pkg/rules/docker-build-rules.yml
 
   docker_no_secrets:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     with:
       artifact_prefix: docker_no_secrets_
 
@@ -300,7 +300,7 @@ jobs:
             core.setFailed("Expected Docker manifest to have been published but output `docker_manifest_published` is false")
 
   no_cross:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: no_cross_
@@ -343,7 +343,7 @@ jobs:
             core.setFailed("Expected Docker manifest to have been published but output `docker_manifest_published` is false")
   
   test_with_alt_pkg:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: test_with_alt_pkg
@@ -368,7 +368,7 @@ jobs:
       rpm_scriptlets_path: pkg/rpm/scriptlets.toml
 
   test_with_alt_cargo_toml:
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@ping-test
     secrets: inherit
     with:
       artifact_prefix: test_with_alt_cargo_toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,6 @@ maintainer = "Ubuntu Jammy Maintainer <ubuntu.jammy@example.com>"
 [package.metadata.deb.variants.debian-buster-arm-unknown-linux-gnueabihf]
 depends = "adduser, passwd, libc6 (>= 2.27), libssl1.1"
 
-[package.metadata.deb.variants.debian-bullseye]
-depends = "$auto, passwd, libssl3"
-
 [package.metadata.deb.variants.debian-bookworm]
 depends = "$auto, passwd, libssl3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,14 @@ assets = [
 ]
 systemd-units = { unit-name = "mytest", unit-scripts = "pkg/common", enable = true }
 
+# By adding the variants defined below we will also then need to provide variant specific systemd files.
+# In pkg/common/ you will see symbolic links used to ensure that the systemd unit files around. Note that
+# if they are missing there will be no failure from cargo-deb during packaging, the failure is only
+# detected during the pkg-test phase (and as that phase is disabled for Debian Stretch and Debian Buster
+# because the LXC images don't exist/don't work properly) the fact that buster specific variant below has
+# no corresponding sym link in pkg/common/ doesn't actually cause our workflow to fail... Maybe cargo-deb
+# should warn about expected but missing systemd files? Maybe cargo-deb should fallback to the non-variant
+# specific unit files?
 [package.metadata.deb.variants.ubuntu-jammy]
 depends = "$auto, passwd, libssl3"
 maintainer = "Ubuntu Jammy Maintainer <ubuntu.jammy@example.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,12 @@ maintainer = "Ubuntu Jammy Maintainer <ubuntu.jammy@example.com>"
 [package.metadata.deb.variants.debian-buster-arm-unknown-linux-gnueabihf]
 depends = "adduser, passwd, libc6 (>= 2.27), libssl1.1"
 
+[package.metadata.deb.variants.debian-bullseye]
+depends = "$auto, passwd, libssl3"
+
+[package.metadata.deb.variants.debian-bookworm]
+depends = "$auto, passwd, libssl3"
+
 [package.metadata.deb.variants.minimal]
 depends = "libc6 (>= 2.27), rsync" # a deliberately different dependency that we can test for on older O/S's.
 maintainer = "Minimal Maintainer <minimal@example.com>"

--- a/pkg/common/mytest-debian-bookworm.mytest.service
+++ b/pkg/common/mytest-debian-bookworm.mytest.service
@@ -1,0 +1,1 @@
+mytest.mytest.service

--- a/pkg/common/mytest-debian-bookworm.mytest.timer
+++ b/pkg/common/mytest-debian-bookworm.mytest.timer
@@ -1,0 +1,1 @@
+mytest.mytest.timer

--- a/pkg/rules/package-build-rules.yml
+++ b/pkg/rules/package-build-rules.yml
@@ -47,6 +47,8 @@ image:
   - "ubuntu:jammy"     # ubuntu/22.04
   - "debian:stretch"
   - "debian:buster"
+  - "debian:bullseye"
+  - "debian:bookworm"
   - 'centos:7'
   - 'rockylinux:8'     # compatible with EOL centos:8
   - 'rockylinux:9'

--- a/pkg/rules/package-test-rules.yml
+++ b/pkg/rules/package-test-rules.yml
@@ -28,8 +28,11 @@ image:
   - "ubuntu:jammy" # ubuntu/22.04
   - "debian:stretch" # should get excluded because the LXC image no longer exists
   - "debian:buster"
+  - "debian:bullseye"
+  - "debian:bookworm"
   - "centos:7"
   - "centos:8"
+  - "rockylinux:9"
 mode:
   - "fresh-install"
 target:


### PR DESCRIPTION
This helps to catch issues like LXC image problems that are specific to a particular LXC image.

This PR also adds the ability to run just one job of the whole test suite, when invoked via manual workflow run from the GH Actions web UI.